### PR TITLE
Add conference/networking templates; prioritize longest Activity run; add Makefile update_and_run; minor typing fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,7 @@ run_demo:
 
 clear_local_env:
 	rm -f activity.joblib
+
+update_and_run: # updates history, fetches activity, do templates, and runs the dashboard
+	uv run python3 -m todoist.automations.update_env --config-dir configs --config-name automations && \
+	PYTHONPATH=. uv run streamlit run todoist/dashboard/app.py --client.showErrorDetails=False

--- a/configs/automations.yaml
+++ b/configs/automations.yaml
@@ -1,4 +1,5 @@
 automations:
+
   - _target_: todoist.automations.template.Template
     task_templates:
       pr:
@@ -24,6 +25,258 @@ automations:
             content: Write review
             description: Write the review
             due_date_days_difference: 0
+      conference_people_scan:
+        _target_: todoist.automations.template.TaskTemplate
+        content: Initial People Scanning
+        description: Identify and scan key people at the conference/summer school
+        due_date_days_difference: 0
+        priority: 1
+        children:
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Get list of participants/speakers
+            description: Download or collect the list from the event website/platform
+            due_date_days_difference: -2
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Mark must-meet researchers
+            description: Choose people you want/need to connect with (advisors, labs, similar topics)
+            due_date_days_difference: -1
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Google/Scholar scan
+            description: Skim recent papers/talks of key people
+            due_date_days_difference: 0
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Write short notes/questions
+            description: Prepare questions or talking points for each person
+            due_date_days_difference: 0
+
+      networking_reachout:
+        _target_: todoist.automations.template.TaskTemplate
+        content: Networking Initial Reachout
+        description: Reach out to researchers or peers during the event
+        due_date_days_difference: 0
+        priority: 1
+        children:
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Draft intro message/email
+            description: Prepare a personal introduction and connection message
+            due_date_days_difference: 0
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Refine intro with AI
+            description: Refine with AI or mentor for clarity and conciseness
+            due_date_days_difference: 0
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Send reachout
+            description: Send intro message via email, LinkedIn, Slack, or in-person
+            due_date_days_difference: 0
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Make a note of response
+            description: Record replies & next steps for each contact
+            due_date_days_difference: 1
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Schedule meeting/coffee
+            description: Arrange a chat (if possible)
+            due_date_days_difference: 2
+
+      networking_followup:
+        _target_: todoist.automations.template.TaskTemplate
+        content: Networking Follow-Up
+        description: Follow up after initial networking
+        due_date_days_difference: 3
+        priority: 1
+        children:
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Review notes from meeting/conversation
+            description: Review what you discussed, summarize key points
+            due_date_days_difference: 1
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Draft follow-up message
+            description: Thank them, mention something specific you discussed, include next steps
+            due_date_days_difference: 2
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Refine follow-up with AI
+            description: Refine text with AI for clarity
+            due_date_days_difference: 2
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Send follow-up message
+            description: Send via appropriate channel (email, LinkedIn, etc.)
+            due_date_days_difference: 3
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Add to contacts notebook
+            description: Maintain a living doc/spreadsheet of your network and notes
+            due_date_days_difference: 4
+
+      talk_attendance:
+        _target_: todoist.automations.template.TaskTemplate
+        content: Talk/Session Attendance
+        description: Attend and get the most out of a talk/session
+        due_date_days_difference: 0
+        priority: 1
+        children:
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Read abstract & speaker bio
+            description: Skim abstract and bio before the talk
+            due_date_days_difference: -1
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Prepare 1-2 questions
+            description: Think of questions to ask during/after the session
+            due_date_days_difference: 0
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Attend talk & take notes
+            description: Focus on main ideas, jot down questions
+            due_date_days_difference: 0
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Summarize key points
+            description: Write a summary of the talk
+            due_date_days_difference: 1
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Reach out to speaker (if relevant)
+            description: Send a question or comment as a follow-up if interested
+            due_date_days_difference: 2
+
+      conference_paper_scan:
+        _target_: todoist.automations.template.TaskTemplate
+        content: Fast Paper Scan
+        description: Efficiently scan through papers/posters at a conference
+        due_date_days_difference: 0
+        priority: 1
+        children:
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Download/bookmark papers of interest
+            description: Collect PDFs, links, or photos of posters
+            due_date_days_difference: 0
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Skim abstracts
+            description: Quickly read abstracts for relevance
+            due_date_days_difference: 0
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Mark high-priority reads
+            description: Star or note which ones to read in depth
+            due_date_days_difference: 0
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Add notes/tags
+            description: Tag with topics/methods for later review
+            due_date_days_difference: 0
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Plan in-depth reads
+            description: Schedule time post-conference for deeper reading
+            due_date_days_difference: 1
+
+      summer_school_project_team:
+        _target_: todoist.automations.template.TaskTemplate
+        content: Summer School Project Teaming
+        description: Organize and contribute to a summer school project
+        due_date_days_difference: 0
+        priority: 1
+        children:
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Read project proposals
+            description: Review all available project ideas
+            due_date_days_difference: 0
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Reach out to possible teammates
+            description: Contact peers to discuss team formation
+            due_date_days_difference: 0
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Attend project kickoff
+            description: Join the initial team/project meeting
+            due_date_days_difference: 0
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Define roles & tasks
+            description: Clarify who does what in the team
+            due_date_days_difference: 0
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Schedule regular check-ins
+            description: Agree on regular meetings or syncs
+            due_date_days_difference: 1
+
+      conference_postmortem:
+        _target_: todoist.automations.template.TaskTemplate
+        content: Conference/Summer School Postmortem
+        description: Reflect and follow up after the event
+        due_date_days_difference: 5
+        priority: 1
+        children:
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Summarize learnings
+            description: Write a summary of what you learned/achieved
+            due_date_days_difference: 1
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Organize notes & materials
+            description: Sort your notes, slides, papers, business cards
+            due_date_days_difference: 2
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Reach out to new contacts
+            description: Thank new connections, send relevant info or ask follow-up questions
+            due_date_days_difference: 3
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Add action items to todo list
+            description: Add any research, reading, or collaboration tasks to your todo list
+            due_date_days_difference: 4
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Update academic CV/website
+            description: Add talks, posters, or experiences to your CV or website
+            due_date_days_difference: 5
+  - _target_: todoist.automations.template.Template
+    task_templates:
+      poster_creation:
+        _target_: todoist.automations.template.TaskTemplate
+        content: Poster Creation
+        description: Prepare and present a research poster
+        due_date_days_difference: 0
+        priority: 1
+        children:
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Review poster guidelines
+            description: Check official poster size, format, and submission requirements
+            due_date_days_difference: -20
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Select content for poster
+            description: Decide on the research, results, and story to present
+            due_date_days_difference: -18
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Sketch poster layout
+            description: Draw a rough layout for sections and flow
+            due_date_days_difference: -17
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Gather figures, charts, and visuals
+            description: Prepare all images, graphs, and diagrams for clarity and impact
+            due_date_days_difference: -15
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Draft poster content
+            description: Write section text (title, intro, methods, results, discussion, references)
+            due_date_days_difference: -14
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Peer/mentor review
+            description: Get feedback on draft content and visuals
+            due_date_days_difference: -12
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Revise poster with feedback
+            description: Update poster with improvements suggested by reviewers
+            due_date_days_difference: -10
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Design and finalize poster
+            description: Use design software to assemble and polish the poster
+            due_date_days_difference: -8
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Print poster or prepare digital version
+            description: Print physical poster or format file for digital presentation
+            due_date_days_difference: -5
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Practice poster pitch
+            description: Rehearse your 1-minute and deep-dive explanations
+            due_date_days_difference: -3
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Gather poster supplies
+            description: Collect poster tube, tape, pushpins, business cards, handouts
+            due_date_days_difference: -2
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Present poster at event
+            description: Arrive early, set up, engage with attendees, take notes on feedback
+            due_date_days_difference: 0
+          - _target_: todoist.automations.template.TaskTemplate
+            content: Follow up with new contacts
+            description: Send thank-you notes, answer questions, and share materials after the event
+            due_date_days_difference: 2
 
       msg:
         _target_: todoist.automations.template.TaskTemplate

--- a/todoist/automations/init_env.py
+++ b/todoist/automations/init_env.py
@@ -6,7 +6,7 @@ from todoist.automations.base import Automation
 from todoist.database.base import Database
 from todoist.utils import try_n_times
 from functools import partial
-
+from todoist.automations.activity import Activity
 
 @hydra.main(version_base=None, config_path=None)
 def main(config: DictConfig) -> None:
@@ -16,6 +16,22 @@ def main(config: DictConfig) -> None:
     dbio = Database('.env')
     automations: list[Automation] = hydra.utils.instantiate(config.automations)
     logger.info("Loaded automations: {}", list(map(str, automations)))
+    
+    # if Activity among automations, we need to run the longest one.
+    activity_automations: list[Activity] = list(filter(lambda x: isinstance(x, Activity), automations))
+    rest_automations = list(filter(lambda x: not isinstance(x, Activity), automations))
+    if activity_automations:
+        longest_automation = max(activity_automations, key=lambda x: x.nweeks)
+        logger.info(f"Activity automations found, running the longest one - last {int(longest_automation.nweeks)} weeks of activity collection.")
+        automations = [longest_automation] + rest_automations
+    else:
+        logger.info("No activity automations found, running all remaining automations.")
+    
+    if not automations:
+        logger.warning("No automations to run. Exiting.")
+        return
+    
+
     logger.info("Starting automations...")
     for automation in tqdm(automations, desc="Processing automations"):
         logger.info("Running automation: {}", automation)

--- a/todoist/automations/update_env.py
+++ b/todoist/automations/update_env.py
@@ -24,8 +24,8 @@ def main(config: DictConfig) -> None:
     activity_automations: list[Activity] = list(filter(lambda x: isinstance(x, Activity), automations))
     rest_automations = list(filter(lambda x: not isinstance(x, Activity), automations))
     if activity_automations:
-        longest_automation = max(activity_automations, key=lambda x: x.frequency_in_minutes)
-        logger.info(f"Activity automations found, running the longest one, each {int(longest_automation.frequency_in_minutes)} minutes.")
+        longest_automation = max(activity_automations, key=lambda x: x.nweeks)
+        logger.info(f"Activity automations found, running the longest one - last {int(longest_automation.nweeks)} weeks of activity collection.")
         automations = [longest_automation] + rest_automations
     else:
         logger.info("No activity automations found, running all remaining automations.")

--- a/todoist/database/db_activity.py
+++ b/todoist/database/db_activity.py
@@ -29,7 +29,7 @@ class DatabaseActivity:
         result: list[Event] = []
 
         def process_page(page: int) -> list[Event]:
-            events: list[_Event_API_V9] = self._fetch_activity_page(page)
+            events: list[Event] = self._fetch_activity_page(page)
             page_events: list[Event] = []
             for event in events:
                 # TODO: Implement a factory method to create the correct Event subclass


### PR DESCRIPTION
Proposed PR title
Add event templates, optimize Activity run, and add update_and_run

Summary
- Makefile: add update_and_run to refresh data and launch dashboard.
- Configs: add event workflow templates (conference, networking, talks, papers, poster).
- Automations (init_env/update_env): run the longest Activity automation; minor refactor/logging and early exit if none.
- DB: small typing fix in db_activity.py.