### PR TITLE
multiplicate depth

### DIFF
--- a/tests/test_multiplicate_depth_sorting.py
+++ b/tests/test_multiplicate_depth_sorting.py
@@ -1,0 +1,73 @@
+from types import SimpleNamespace
+
+from todoist.automations.multiplicate import Multiply
+from todoist.types import Task, TaskEntry
+
+
+def _task_entry(
+    *,
+    task_id: str,
+    content: str,
+    labels: list[str],
+    parent_id: str | None = None,
+) -> TaskEntry:
+    # Minimal constructor for the TaskEntry dataclass.
+    return TaskEntry(
+        id=task_id,
+        is_deleted=False,
+        added_at="",
+        child_order=0,
+        responsible_uid=None,
+        content=content,
+        description="",
+        user_id="",
+        assigned_by_uid="",
+        project_id="p1",
+        section_id="s1",
+        sync_id=None,
+        collapsed=False,
+        due=None,
+        parent_id=parent_id,
+        labels=labels,
+        checked=False,
+        priority=1,
+        note_count=0,
+        added_by_uid="",
+        completed_at=None,
+        deadline=None,
+        duration=None,
+        updated_at="",
+        v2_id=None,
+        v2_parent_id=None,
+        v2_project_id=None,
+        v2_section_id=None,
+        day_order=None,
+        new_api_kwargs=None,
+    )
+
+
+class _FakeDb:
+    def __init__(self, tasks: list[Task]):
+        self._projects = [SimpleNamespace(tasks=tasks)]
+        self.removed_ids: list[str] = []
+
+    def fetch_projects(self, include_tasks: bool = True):
+        return self._projects
+
+    def insert_task_from_template(self, *args, **kwargs):
+        return None
+
+    def remove_task(self, task_id: str) -> bool:
+        self.removed_ids.append(task_id)
+        return True
+
+
+def test_tasks_sorted_by_depth_parent_before_child():
+    parent = Task(id="1", task_entry=_task_entry(task_id="1", content="P", labels=["X2"]))
+    child = Task(id="2", task_entry=_task_entry(task_id="2", content="C", labels=["X2"], parent_id="1"))
+
+    # Deliberately provide child first; Multiply should process parent before child.
+    db = _FakeDb(tasks=[child, parent])
+    Multiply()._tick(db)
+
+    assert db.removed_ids == ["1", "2"]

--- a/todoist/automations/multiplicate.py
+++ b/todoist/automations/multiplicate.py
@@ -23,13 +23,57 @@ class Multiply(Automation):
 
     def _tick(self, db):
         projects = db.fetch_projects(include_tasks=True)
-        all_tasks: Iterable[Task] = [task for project in projects for task in project.tasks]
-        logger.debug(f"Found {len(list(all_tasks))} tasks in total")
+        all_tasks: list[Task] = [task for project in projects for task in project.tasks]
+        logger.debug(f"Found {len(all_tasks)} tasks in total")
         all_unique_labels = set(tag for task in all_tasks for tag in task.task_entry.labels)
         logger.debug(f"Found {len(all_unique_labels)} unique labels")
 
         tasks_to_multiply = list(
             filter(lambda task: any(is_multiplication_label(tag) for tag in task.task_entry.labels), all_tasks))
+
+        # Sort by depth so parent tasks are processed before their subtasks.
+        # Depth is computed from the parent chain (root tasks have depth 0).
+        task_by_id: dict[str, Task] = {task.id: task for task in all_tasks}
+        depth_cache: dict[str, int] = {}
+
+        def depth(task: Task) -> int:
+            task_id = task.id
+            if task_id in depth_cache:
+                return depth_cache[task_id]
+
+            seen: set[str] = set()
+            current: Task | None = task
+            current_depth = 0
+            while current is not None:
+                if current.id in seen:
+                    logger.warning(
+                        f"Detected parent cycle while computing depth for task {task_id}; treating as root"
+                    )
+                    current_depth = 0
+                    break
+                seen.add(current.id)
+
+                parent_id = current.task_entry.parent_id or current.task_entry.v2_parent_id
+                if parent_id is None:
+                    break
+
+                parent = task_by_id.get(parent_id)
+                if parent is None:
+                    # Parent not present in the fetched snapshot; treat as root boundary.
+                    break
+
+                # If we already know the parent's depth, we can finish quickly.
+                if parent.id in depth_cache:
+                    current_depth += 1 + depth_cache[parent.id]
+                    break
+
+                current_depth += 1
+                current = parent
+
+            depth_cache[task_id] = current_depth
+            return current_depth
+
+        tasks_to_multiply.sort(key=depth)
 
         logger.info(f"Found {len(tasks_to_multiply)} tasks to multiply")
         for task in tasks_to_multiply:

--- a/todoist/types.py
+++ b/todoist/types.py
@@ -166,7 +166,6 @@ class Task:
     def is_non_recurring(self) -> bool:
         return is_non_recurring_task(self)
 
-
 @dataclass
 class Project:
     id: str


### PR DESCRIPTION
This pull request introduces a depth-based sorting mechanism to ensure parent tasks are processed before their subtasks during task multiplication, and adds a targeted test to verify this behavior. The main focus is on improving the reliability of the multiplication automation by handling parent-child relationships correctly.

**Depth-based task processing and testing improvements:**

* Added a depth computation and sorting step in `Multiply._tick` to ensure parent tasks are always processed before their children, preventing issues when multiplying tasks with dependencies.
* Introduced a new test file `tests/test_multiplicate_depth_sorting.py` with a unit test that verifies parent tasks are removed before their children, ensuring the new sorting logic works as intended.

**Minor cleanup:**

* Removed an unnecessary blank line in `todoist/types.py` for code cleanliness.