### PR TITLE
Centralize Todoist API constants with StrEnum

### DIFF
--- a/todoist/automations/multiplicate.py
+++ b/todoist/automations/multiplicate.py
@@ -6,6 +6,7 @@ from typing import Iterable, Sequence
 from loguru import logger
 
 from todoist.automations.base import Automation
+from todoist.constants import TaskField
 from todoist.database.base import Database
 from todoist.types import Task, TaskEntry
 
@@ -374,9 +375,9 @@ class Multiply(Automation):
                 old_parent_id, current_new_parent_id = stack.pop()
                 for child in children_by_parent.get(old_parent_id, []):
                     overrides: dict[str, object] = {
-                        "content": child.task_entry.content,
-                        "labels": list(child.task_entry.labels),
-                        "parent_id": current_new_parent_id,
+                        TaskField.CONTENT.value: child.task_entry.content,
+                        TaskField.LABELS.value: list(child.task_entry.labels),
+                        TaskField.PARENT_ID.value: current_new_parent_id,
                     }
                     created = db.insert_task_from_template(child, **overrides)
                     new_child_id = str(created.get("id", "")) if isinstance(created, dict) else ""
@@ -414,9 +415,12 @@ class Multiply(Automation):
             for i in range(1, n + 1):
                 content = _render(self.config.flat_leaf_template, base=base, i=i, n=n)
                 logger.debug(f"Creating flat task: {content}")
-                overrides: dict[str, object] = {"content": content, "labels": labels}
+                overrides: dict[str, object] = {
+                    TaskField.CONTENT.value: content,
+                    TaskField.LABELS.value: labels,
+                }
                 if parent_id is not None:
-                    overrides["parent_id"] = parent_id
+                    overrides[TaskField.PARENT_ID.value] = parent_id
 
                 created = db.insert_task_from_template(task, **overrides)
                 new_id = str(created.get("id", "")) if isinstance(created, dict) else ""

--- a/todoist/automations/template.py
+++ b/todoist/automations/template.py
@@ -1,6 +1,7 @@
 from inspect import signature
 from typing import Any, Final, Iterable, Mapping
 from todoist.automations.base import Automation
+from todoist.constants import TaskField
 from todoist.database.base import Database
 from todoist.types import Task, TaskEntry
 from loguru import logger
@@ -47,12 +48,14 @@ class TaskTemplate:
         if isinstance(config, TaskTemplate):
             return config
 
-        content = config.get('content')
+        content = config.get(TaskField.CONTENT.value)
         if content is None:
-            raise ValueError(f"Missing required field 'content' in TaskTemplate config: {config}")
-        description = config.get('description')
+            raise ValueError(
+                f"Missing required field '{TaskField.CONTENT.value}' in TaskTemplate config: {config}"
+            )
+        description = config.get(TaskField.DESCRIPTION.value)
         due_date_days_difference = config.get('due_date_days_difference', 0)
-        priority = config.get('priority', 1)
+        priority = config.get(TaskField.PRIORITY.value, 1)
         children = [cls.from_config(child) for child in config.get('children', [])]
 
         return cls(content=content,

--- a/todoist/constants.py
+++ b/todoist/constants.py
@@ -1,0 +1,40 @@
+"""Centralized Todoist constant definitions."""
+
+from enum import StrEnum
+
+
+class TaskField(StrEnum):
+    CONTENT = "content"
+    DESCRIPTION = "description"
+    PROJECT_ID = "project_id"
+    SECTION_ID = "section_id"
+    PARENT_ID = "parent_id"
+    ORDER = "order"
+    LABELS = "labels"
+    PRIORITY = "priority"
+    DUE_STRING = "due_string"
+    DUE_DATE = "due_date"
+    DUE_DATETIME = "due_datetime"
+    DUE_LANG = "due_lang"
+    ASSIGNEE_ID = "assignee_id"
+    DURATION = "duration"
+    DURATION_UNIT = "duration_unit"
+    DEADLINE_DATE = "deadline_date"
+    DEADLINE_LANG = "deadline_lang"
+    NAME = "name"
+    ID = "id"
+
+
+class EventExtraField(StrEnum):
+    CONTENT = "content"
+    NAME = "name"
+    DUE_DATE = "due_date"
+    LAST_DUE_DATE = "last_due_date"
+
+
+class EventType(StrEnum):
+    ADDED = "added"
+    UPDATED = "updated"
+    COMPLETED = "completed"
+    DELETED = "deleted"
+    RESCHEDULED = "rescheduled"

--- a/todoist/database/dataframe.py
+++ b/todoist/database/dataframe.py
@@ -1,3 +1,4 @@
+from todoist.constants import EventExtraField
 from todoist.database.base import Database
 from todoist.types import SUPPORTED_EVENT_TYPES, Event, events_to_dataframe
 import pandas as pd
@@ -18,10 +19,10 @@ def extract_name(event: Event) -> str | None:
     Extracts the event name from the event's extra data.
     """
     extra = event.event_entry.extra_data
-    if 'content' in extra:
-        return extra['content']
-    if 'name' in extra:
-        return extra['name']
+    if EventExtraField.CONTENT in extra:
+        return extra[EventExtraField.CONTENT]
+    if EventExtraField.NAME in extra:
+        return extra[EventExtraField.NAME]
     return None
 
 

--- a/todoist/database/db_tasks.py
+++ b/todoist/database/db_tasks.py
@@ -9,6 +9,7 @@ from loguru import logger
 from tqdm import tqdm
 
 from todoist.api import RequestSpec, TodoistAPIClient, TodoistEndpoints
+from todoist.constants import TaskField
 from todoist.api.client import EndpointCallResult
 from todoist.types import Task
 from todoist.utils import MaxRetriesExceeded, RETRY_MAX_ATTEMPTS, with_retry
@@ -123,23 +124,23 @@ class DatabaseTasks:
             'deadline': None}
         """
         payload = {
-            "content": content,
-            "description": description,
-            "project_id": project_id,
-            "section_id": section_id,
-            "parent_id": parent_id,
-            "order": order,
-            "labels": labels,
-            "priority": priority,
-            "due_string": due_string,
-            "due_date": due_date,
-            "due_datetime": due_datetime,
-            "due_lang": due_lang,
-            "assignee_id": assignee_id,
-            "duration": duration,
-            "duration_unit": duration_unit,
-            "deadline_date": deadline_date,
-            "deadline_lang": deadline_lang
+            TaskField.CONTENT.value: content,
+            TaskField.DESCRIPTION.value: description,
+            TaskField.PROJECT_ID.value: project_id,
+            TaskField.SECTION_ID.value: section_id,
+            TaskField.PARENT_ID.value: parent_id,
+            TaskField.ORDER.value: order,
+            TaskField.LABELS.value: labels,
+            TaskField.PRIORITY.value: priority,
+            TaskField.DUE_STRING.value: due_string,
+            TaskField.DUE_DATE.value: due_date,
+            TaskField.DUE_DATETIME.value: due_datetime,
+            TaskField.DUE_LANG.value: due_lang,
+            TaskField.ASSIGNEE_ID.value: assignee_id,
+            TaskField.DURATION.value: duration,
+            TaskField.DURATION_UNIT.value: duration_unit,
+            TaskField.DEADLINE_DATE.value: deadline_date,
+            TaskField.DEADLINE_LANG.value: deadline_lang,
         }
 
         payload = {k: v for k, v in payload.items() if v is not None}
@@ -213,16 +214,16 @@ class DatabaseTasks:
         """
 
         payload = {
-            "content": content,
-            "description": description,
-            "labels": labels,
-            "priority": priority,
-            "due_string": due_string,
-            "due_date": due_date,
-            "due_datetime": due_datetime,
-            "due_lang": due_lang,
-            "duration": duration,
-            "duration_unit": duration_unit,
+            TaskField.CONTENT.value: content,
+            TaskField.DESCRIPTION.value: description,
+            TaskField.LABELS.value: labels,
+            TaskField.PRIORITY.value: priority,
+            TaskField.DUE_STRING.value: due_string,
+            TaskField.DUE_DATE.value: due_date,
+            TaskField.DUE_DATETIME.value: due_datetime,
+            TaskField.DUE_LANG.value: due_lang,
+            TaskField.DURATION.value: duration,
+            TaskField.DURATION_UNIT.value: duration_unit,
         }
         payload = {k: v for k, v in payload.items() if v is not None}
         if not payload:
@@ -341,7 +342,9 @@ class DatabaseTasks:
             """Insert a single task with built-in retry logic."""
             return with_retry(
                 partial(insert_single_task, task_data, index),
-                operation_name=f"insert task {index} (content: {task_data.get('content', 'N/A')})",
+                operation_name=(
+                    f"insert task {index} (content: {task_data.get(TaskField.CONTENT.value, 'N/A')})"
+                ),
                 max_attempts=RETRY_MAX_ATTEMPTS
             )
 

--- a/todoist/types.py
+++ b/todoist/types.py
@@ -5,6 +5,8 @@ from typing import Any
 from loguru import logger
 from pandas import DataFrame
 
+from todoist.constants import EventExtraField, EventType
+
 
 @dataclass
 class _ProjectEntry_API_V9:
@@ -192,14 +194,14 @@ def is_event_rescheduled(event: 'Event') -> bool:
         
     """
     return all([
-        event.event_entry.event_type == 'updated',
-        'due_date' in event.event_entry.extra_data,
-        'last_due_date' in event.event_entry.extra_data,
+        event.event_entry.event_type == EventType.UPDATED.value,
+        EventExtraField.DUE_DATE in event.event_entry.extra_data,
+        EventExtraField.LAST_DUE_DATE in event.event_entry.extra_data,
     ])
 
 
 _EVENT_SUBTYPES_MAPPING = {
-    'rescheduled': is_event_rescheduled,
+    EventType.RESCHEDULED: is_event_rescheduled,
 }
 
 
@@ -220,10 +222,10 @@ class Event:
 
     @property
     def name(self) -> str | None:
-        if 'content' in self.event_entry.extra_data:
-            return self.event_entry.extra_data['content']
-        if 'name' in self.event_entry.extra_data:
-            return self.event_entry.extra_data['name']
+        if EventExtraField.CONTENT in self.event_entry.extra_data:
+            return self.event_entry.extra_data[EventExtraField.CONTENT]
+        if EventExtraField.NAME in self.event_entry.extra_data:
+            return self.event_entry.extra_data[EventExtraField.NAME]
         return None
 
     @property
@@ -236,14 +238,19 @@ class Event:
         For example, 'updated' is a basic type,
         but it is extended with 1 subtype 'rescheduled' (of 'updated').
         """
-        matched_types = [event_type for event_type, is_match in _EVENT_SUBTYPES_MAPPING.items() if is_match(self)]
+        matched_types = [event_type.value for event_type, is_match in _EVENT_SUBTYPES_MAPPING.items() if is_match(self)]
         if len(matched_types) > 0:
             assert len(matched_types) == 1, 'More than one event type matched'
             return matched_types[0]
         return self.event_entry.event_type
 
 
-SUPPORTED_EVENT_TYPES = ['added', 'updated', 'completed', 'deleted']
+SUPPORTED_EVENT_TYPES = [
+    EventType.ADDED.value,
+    EventType.UPDATED.value,
+    EventType.COMPLETED.value,
+    EventType.DELETED.value,
+]
 
 
 def events_to_dataframe(


### PR DESCRIPTION
## Summary
- add StrEnum-based constants for Todoist task fields and event metadata
- refactor automations and database helpers to reuse the centralized field names
- align event handling helpers and dataframe utilities with the shared enums

## Testing
- python -m pytest *(fails: missing dependencies such as pandas, requests, google, loguru, joblib in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f2de6f06083309da8b2e6b3391001)