### PR TITLE
Multiplatform secret handling

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -68,14 +68,20 @@ jobs:
           }
 
       - name: Prepare signing certificate
-        if: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE }}
         shell: powershell
+        env:
+          WINDOWS_SIGNING_CERTIFICATE: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE }}
+          WINDOWS_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}
         run: |
-          $certBase64 = '${{ secrets.WINDOWS_SIGNING_CERTIFICATE }}'
+          if (-not $env:WINDOWS_SIGNING_CERTIFICATE) {
+            Write-Host 'Signing certificate secret not set; skipping.'
+            exit 0
+          }
+          $certBase64 = $env:WINDOWS_SIGNING_CERTIFICATE
           $certPath = Join-Path $env:GITHUB_WORKSPACE 'todoist-assistant.pfx'
           [IO.File]::WriteAllBytes($certPath, [Convert]::FromBase64String($certBase64))
           "WINDOWS_SIGNING_CERTIFICATE=$certPath" | Out-File -FilePath $env:GITHUB_ENV -Append
-          "WINDOWS_SIGNING_CERTIFICATE_PASSWORD=${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "WINDOWS_SIGNING_CERTIFICATE_PASSWORD=$($env:WINDOWS_SIGNING_CERTIFICATE_PASSWORD)" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Build MSI
         shell: powershell


### PR DESCRIPTION
This pull request updates the Windows installer workflow to improve handling of the signing certificate and its password. The main change is to ensure that the signing certificate step is skipped gracefully if the required secret is not set, and to use environment variables for secrets instead of direct expressions.

Changes to signing certificate handling:

* The signing certificate preparation step now checks if the `WINDOWS_SIGNING_CERTIFICATE` secret is set before proceeding, and exits early with a clear message if it's missing.
* Secrets for the signing certificate and its password are now passed via environment variables, improving consistency and security in the workflow.