### PR TITLE
Continuous Breakdown 

### DIFF
--- a/configs/automations.yaml
+++ b/configs/automations.yaml
@@ -39,7 +39,7 @@ llm_breakdown:
   allow_existing_children: false
   remove_label_after_processing: true
   propagate_labels: true
-  max_tasks_per_tick: 1
+  max_tasks_per_tick: 0
   max_queue_depth: 1
   auto_queue_children: true
   variants:

--- a/todoist/automations/llm_breakdown/automation.py
+++ b/todoist/automations/llm_breakdown/automation.py
@@ -84,7 +84,7 @@ class LLMBreakdown(Automation):
         self.allow_existing_children = settings_obj.allow_existing_children
         self.remove_label_after_processing = settings_obj.remove_label_after_processing
         self.propagate_labels = settings_obj.propagate_labels
-        self.max_tasks_per_tick = max(1, int(settings_obj.max_tasks_per_tick))
+        self.max_tasks_per_tick = max(0, int(settings_obj.max_tasks_per_tick))
         self.max_queue_depth = max(1, int(settings_obj.max_queue_depth))
         self.auto_queue_children = settings_obj.auto_queue_children
         self.track_progress = settings_obj.track_progress

--- a/todoist/automations/llm_breakdown/runner.py
+++ b/todoist/automations/llm_breakdown/runner.py
@@ -118,7 +118,8 @@ def run_breakdown(automation: Any, db: Database) -> None:
         logger.info("No LLM breakdown tasks queued.")
         return
 
-    tasks_to_process = candidates[:automation.max_tasks_per_tick]
+    limit = automation.max_tasks_per_tick
+    tasks_to_process = candidates[:limit] if limit > 0 else candidates
     tasks_total = len(candidates)
     tasks_pending = tasks_total - len(tasks_to_process)
     run_id = automation.new_run_id()


### PR DESCRIPTION
This pull request updates the `llm_breakdown` automation to allow for more flexible processing of tasks per tick, including the option to process all queued tasks at once. The main changes involve configuration, initialization, and runner logic to support a `max_tasks_per_tick` value of zero, which now means "no limit" instead of "minimum one".

Configuration and Initialization:

* Updated `configs/automations.yaml` to allow `max_tasks_per_tick` to be set to zero, removing the previous minimum of one.
* Changed the initialization in `automation.py` so that `max_tasks_per_tick` can be zero (removing the previous minimum of one), enabling unlimited task processing per tick.

Task Processing Logic:

* Modified the logic in `runner.py` to process all candidate tasks if `max_tasks_per_tick` is zero, instead of limiting to one or more.